### PR TITLE
Beiträge: Beiträge immer noch im voraus, aber nicht umbedingt jährlich.

### DIFF
--- a/statuten.md
+++ b/statuten.md
@@ -46,7 +46,7 @@ Es haftet ausschliesslich das Vereinsvermögen.
 ## 5 Beiträge
 
 Der Mitgliederbeitrag berechnet sich nach der Anzahl vertretener Hacker. Er ist
-jährlich im Voraus fällig.
+im Voraus fällig.
 
 ## 6 Organe
 

--- a/statuti.md
+++ b/statuti.md
@@ -42,7 +42,7 @@ Per i debiti dell’associazione risponde solo il patrimonio dell’associazione
 ## 5 contributi
 
 I contributi sociali riflettono il numero degli hacker rappresentati.
-Questi sono dovuti annualmente ed in anticipo.
+Questi sono dovuti in anticipo.
 
 ## 6 organi
 

--- a/statuts.md
+++ b/statuts.md
@@ -41,7 +41,7 @@ Responsable aux dettes de l’association est seulement la fortune de l’associ
 ## 5 contributions
 
 La cotisation est calculée du nombre des hackers représentés.
-Elle est due annuellement et en avance.
+Elle est due en avance.
 
 ## 6 organes
 


### PR DESCRIPTION
Das sollen Vorstand und Kassiers der Mitglieder untereinander abmachen; braucht nicht in den Statuten zu stehen.

(export from #7 )