### PR TITLE
Revisionsstelle: eindeutiger formuliert, so dass klar wird dass die Revisoren nicht z.B. 5 sein können wovon 2 nicht im Vorstand sind.

### DIFF
--- a/statuten.md
+++ b/statuten.md
@@ -99,8 +99,8 @@ aber nicht unbedingt demselben, angehören. Er konstituiert sich selbst.
 
 ## 9 Revisionsstelle
 
-Die Revisionsstelle besteht aus mindestens zwei Personen, die nicht dem
-Vorstand angehören. Sie prüft die Rechnungslegung und berichtet der
+Die Revisionsstelle besteht aus mindestens zwei Personen. Diese gehören nicht dem
+Vorstand an. Die Revisionsstelle prüft die Rechnungslegung und berichtet der
 ordentlichen Chaosversammlung.
 
 ## 10 Auflösung des Verbands

--- a/statuten.md
+++ b/statuten.md
@@ -99,7 +99,7 @@ aber nicht unbedingt demselben, angehören. Er konstituiert sich selbst.
 
 ## 9 Revisionsstelle
 
-Die Revisionsstelle besteht aus mindestens zwei Personen. Diese gehören nicht dem
+Die Revisionsstelle besteht aus mindestens zwei Personen. Ihre Mitglieder gehören nicht dem
 Vorstand an. Die Revisionsstelle prüft die Rechnungslegung und berichtet der
 ordentlichen Chaosversammlung.
 


### PR DESCRIPTION
(export from #7)